### PR TITLE
Return interface{} so cast doesn't fail; don't export unecessary structs

### DIFF
--- a/app_service/app_service.go
+++ b/app_service/app_service.go
@@ -6,13 +6,14 @@ package main
 
 import (
 	"flag"
-	"github.com/aknott2210/os_service/arguments"
-	"github.com/kardianos/service"
 	"log"
 	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
+
+	"github.com/aknott2210/os_srvc/arguments"
+	"github.com/kardianos/service"
 )
 
 var logger service.Logger


### PR DESCRIPTION
Added return of interface for get calls
Don't export the unneeded structs